### PR TITLE
Added appVersion setter and flipped setters

### DIFF
--- a/src/System/Console/ArgParser.hs
+++ b/src/System/Console/ArgParser.hs
@@ -62,6 +62,10 @@ module System.Console.ArgParser (
   , Descr (Descr)
   , setAppDescr
   , setAppEpilog
+  , setAppVersion
+  , setDescr
+  , setVersion
+  , setEpilog
   -- ** Sub commands
   -- $subparser
   , mkSubParser
@@ -96,7 +100,11 @@ import           System.Console.ArgParser.QuickParams
 import           System.Console.ArgParser.Run         (mkApp, mkDefaultApp,
                                                        parseArgs, runApp,
                                                        setAppDescr,
-                                                       setAppEpilog,
+                                                       setAppEpilog, 
+                                                       setAppVersion,
+                                                       setDescr,
+                                                       setEpilog,
+                                                       setVersion,
                                                        withParseResult)
 import           System.Console.ArgParser.SubParser   (mkSubParser)
 

--- a/src/System/Console/ArgParser/Format.hs
+++ b/src/System/Console/ArgParser/Format.hs
@@ -36,7 +36,7 @@ data CmdLineFormat = CmdLineFormat
 
 -- | Default specification for the help layout
 defaultFormat :: CmdLineFormat
-defaultFormat = CmdLineFormat 75 1 80
+defaultFormat = CmdLineFormat 45 1 50
 
 -- | Prints the application name and version
 showCmdLineVersion :: CmdLnInterface a -> String

--- a/src/System/Console/ArgParser/Format.hs
+++ b/src/System/Console/ArgParser/Format.hs
@@ -36,7 +36,7 @@ data CmdLineFormat = CmdLineFormat
 
 -- | Default specification for the help layout
 defaultFormat :: CmdLineFormat
-defaultFormat = CmdLineFormat 45 1 50
+defaultFormat = CmdLineFormat 30 2 80
 
 -- | Prints the application name and version
 showCmdLineVersion :: CmdLnInterface a -> String

--- a/src/System/Console/ArgParser/Format.hs
+++ b/src/System/Console/ArgParser/Format.hs
@@ -36,7 +36,7 @@ data CmdLineFormat = CmdLineFormat
 
 -- | Default specification for the help layout
 defaultFormat :: CmdLineFormat
-defaultFormat = CmdLineFormat 30 1 35
+defaultFormat = CmdLineFormat 75 1 80
 
 -- | Prints the application name and version
 showCmdLineVersion :: CmdLnInterface a -> String

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -52,7 +52,7 @@ runApp
   -> IO ()
 runApp appspec appfun = do
   args <- getArgs
-  either putStrLn appfun $ parseArgs args appspec
+  either printError appfun $ parseArgs args appspec
     where printError err = do
             putStrLn err
             putStrLn (showCmdLineAppUsage defaultFormat appspec)

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -22,6 +22,7 @@ module System.Console.ArgParser.Run (
   , defaultSpecialFlags
   , setAppDescr
   , setAppEpilog
+  , setAppVersion
   , setAppName
   ) where
 
@@ -131,6 +132,15 @@ setAppDescr app descr = app {getAppDescr = Just descr }
 setAppEpilog :: CmdLnInterface a -> String -> CmdLnInterface a
 setAppEpilog app descr = app {getAppEpilog = Just descr }
 
+-- | Set the version of an interface
+setAppVersion :: CmdLnInterface a -> String -> CmdLnInterface a
+setAppVersion app ver = app {getAppVersion = Just ver }
+
 -- | Set the name of an interface
 setAppName :: CmdLnInterface a -> String -> CmdLnInterface a
 setAppName app descr = app {getAppName = descr }
+
+-- | Flipped setters (useful to apply using fmap)
+setDescr = flip setAppDescr
+setEpilog = flip setAppEpilog
+setVersin = flip setAppVersion

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -24,6 +24,10 @@ module System.Console.ArgParser.Run (
   , setAppEpilog
   , setAppVersion
   , setAppName
+  , setDescr
+  , setVersion
+  , setEpilog
+  , setName
   ) where
 
 import           Control.Monad
@@ -141,6 +145,14 @@ setAppName :: CmdLnInterface a -> String -> CmdLnInterface a
 setAppName app descr = app {getAppName = descr }
 
 -- | Flipped setters (useful to apply using fmap)
+setDescr :: String -> CmdLnInterface a -> CmdLnInterface a
 setDescr = flip setAppDescr
+
+setEpilog :: String -> CmdLnInterface a -> CmdLnInterface a
 setEpilog = flip setAppEpilog
-setVersin = flip setAppVersion
+
+setVersion :: String -> CmdLnInterface a -> CmdLnInterface a
+setVersion = flip setAppVersion
+
+setName :: String -> CmdLnInterface a -> CmdLnInterface a
+setName = flip setAppName

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -52,10 +52,7 @@ runApp
   -> IO ()
 runApp appspec appfun = do
   args <- getArgs
-  either printError appfun $ parseArgs args appspec
-    where printError err = do
-            putStrLn err
-            putStrLn (showCmdLineAppUsage defaultFormat appspec)
+  either putStrLn appfun $ parseArgs args appspec
 
 
 -- | Runs an apllication with the user provided arguments.

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -27,7 +27,6 @@ module System.Console.ArgParser.Run (
   , setDescr
   , setVersion
   , setEpilog
-  , setName
   ) where
 
 import           Control.Monad
@@ -153,6 +152,3 @@ setEpilog = flip setAppEpilog
 
 setVersion :: String -> CmdLnInterface a -> CmdLnInterface a
 setVersion = flip setAppVersion
-
-setName :: String -> CmdLnInterface a -> CmdLnInterface a
-setName = flip setAppName

--- a/src/System/Console/ArgParser/Run.hs
+++ b/src/System/Console/ArgParser/Run.hs
@@ -53,6 +53,10 @@ runApp
 runApp appspec appfun = do
   args <- getArgs
   either putStrLn appfun $ parseArgs args appspec
+    where printError err = do
+            putStrLn err
+            putStrLn (showCmdLineAppUsage defaultFormat appspec)
+
 
 -- | Runs an apllication with the user provided arguments.
 --   It is a shorter way of calling `mkApp` and `runApp`

--- a/src/System/Console/ArgParser/SubParser.hs
+++ b/src/System/Console/ArgParser/SubParser.hs
@@ -56,7 +56,7 @@ mkSpecialFlag topname subapps = (parser, action) where
 data EmptyParam a = EmptyParam
 
 instance ParamSpec EmptyParam where
-  getParser _ = Parser $ \args -> (Left "command not found", args)
+  getParser _ = Parser $ \args -> (Left "subcommand not provided", args)
   getParamDescr _ = []
 
 data CommandParam appT resT = CommandParam 


### PR DESCRIPTION
I've added the app version setter ```setAppVersion``` that was missing for some reason I couln't find.

I've also made a few changes that helps to write the application strings easily when using mkSubParser:
Adding a flipped version of setAppDescr, setAppEpilog and setAppVersion allows to use infix ```<$>``` to write something like:

```
-- This is my main cli parser
mainParser :: IO (CmdLnInterface MyType)
mainParser = mkSubParser 
    [ ("subaction1", mkDefaultApp subAction1Parser "subaction1") 
    , ("subaction2", mkDefaultApp subAction2Parser "subaction2") ]

-- and the main parser including descriptive strings can be written like this
parseCli :: IO (CmdLnInterface MyType)
parseCli = setVersion "1.2.3"
       <$> setDescr "My application description"
       <$> setEpilog "My application epilog"
       <$> mainParser
```
Which I found clearer to understand than the current implementation.

I really hope you found this changes useful.

Regards.
Agustín.