### PR TITLE
`Maybe a` instance of RawRead

### DIFF
--- a/src/System/Console/ArgParser/QuickParams.hs
+++ b/src/System/Console/ArgParser/QuickParams.hs
@@ -79,6 +79,11 @@ instance RawRead Char where
 instance RawRead a => RawRead [a] where
   rawParse s = Just (unfoldr rawParse s, [])
 
+instance RawRead a => RawRead (Maybe a) where
+  rawParse s = case rawParse s of
+    Nothing -> Nothing
+    Just (p, s') -> Just (Just p, s')
+
 instance RawRead Float where
   rawParse = defaultRawParse
 

--- a/tests/System/Console/ArgParser/QuickParamsTest.hs
+++ b/tests/System/Console/ArgParser/QuickParamsTest.hs
@@ -80,6 +80,19 @@ test_optFlagFailure = behavior intOptFlagParser
   , (willSucceed 0, [])
   ]
 
+maybeIntOptFlagParser :: [String] -> ParseResult (Maybe Int)
+maybeIntOptFlagParser = paramRun $ optFlag Nothing "test"
+
+prop_maybeOptFlagSuccess :: Positive Int -> Bool
+prop_maybeOptFlagSuccess = getMaybeIntSuccessProp maybeIntOptFlagParser (\i -> ["-t", show i])
+
+test_maybeOptFlagFailure :: H.Assertion
+test_maybeOptFlagFailure = behavior maybeIntOptFlagParser
+  [ (willFail, ["--test"])
+  , (willFail, ["--test", "foo"])
+  , (willSucceed Nothing, [])
+  , (willSucceed (Just 1), ["--test", "1"])]
+
 intOptArgsParser :: [String] -> ParseResult Int
 intOptArgsParser = paramRun $ posArgs "test" 0 (+)
 

--- a/tests/System/Console/ArgParser/TestHelpers.hs
+++ b/tests/System/Console/ArgParser/TestHelpers.hs
@@ -58,6 +58,15 @@ getIntSuccessProp
 getIntSuccessProp parser repr = prop where
   prop (Positive i) = (Right i ==) $ parser $ repr i
 
+getMaybeIntSuccessProp
+  :: (Eq a)
+  => ([String] -> ParseResult (Maybe a))
+  -> (a -> [String])
+  -> Positive a
+  -> Bool
+getMaybeIntSuccessProp parser repr = prop where
+  prop (Positive i) = (Right (Just i) ==) $ parser $ repr i
+
 getStrSuccessProp
   :: ([String] -> ParseResult String)
   -> String


### PR DESCRIPTION
This PR provides the ability to use `Maybe a` types in the datatype target of parsing. This is particularly useful for optional arguments that don't have a natural "default".

Imagine an `--limit` flag argument where the application operates "unbounded" if no limit is provided. You could use `-1` as a default (or some other magic number) to fake this behavior, but using `Maybe Int` is much cleaner.

Currently this functionality requires creating a custom Argument with a custom parser. This seems like a reasonably common case for a command line application so I'd like to add first class support for it.